### PR TITLE
fix: add version to release files command

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -33,4 +33,4 @@ runs:
         echo "${GITHUB_REPOSITORY}@${{ steps.setSHAs.outputs.base }}..${{ steps.setSHAs.outputs.head }}"
         sentry-cli releases new "${SENTRY_RELEASE}"
         sentry-cli releases set-commits "${SENTRY_RELEASE}" --commit "${GITHUB_REPOSITORY}@${{ steps.setSHAs.outputs.base }}..${{ steps.setSHAs.outputs.head }}"
-        sentry-cli releases files upload-sourcemaps ${{ inputs.sourcemap-flags }} --validate sourcemaps --wait .
+        sentry-cli releases files "${SENTRY_RELEASE}" upload-sourcemaps ${{ inputs.sourcemap-flags }} --validate sourcemaps --wait .


### PR DESCRIPTION
Fixes the following error:

```
error: The following required arguments were not provided:
    <VERSION>

USAGE:
    sentry-cli releases files <VERSION> <SUBCOMMAND>
```